### PR TITLE
Adapt offset learning to interact with hardware backend

### DIFF
--- a/lcls_beamline_toolbox/utility/bluesky_alignment.py
+++ b/lcls_beamline_toolbox/utility/bluesky_alignment.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 import numpy as np
 from scipy.optimize import curve_fit
 

--- a/lcls_beamline_toolbox/utility/phase1_offset_calibration.py
+++ b/lcls_beamline_toolbox/utility/phase1_offset_calibration.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import math
 
 import bluesky.plan_stubs as bps
 
@@ -10,51 +9,90 @@ from lcls_beamline_toolbox.utility.bluesky_alignment import scan_fit_center
 
 def learn_phase1_offset(
     *,
-    RE_sim,
+    RE,
     sim_backend,
-    RE_hw,
     hw_backend,
     motor_attr,
     detector_attr,
+    norm_detector_attr,
     offset_pv,
     start,
     stop,
     steps,
     shots_per_step=1,
+    duration=2,
     move=True,
     write=False,
-    caput_fn=None,
 ):
     """
     Run one paired Phase 1 scan on simulation and hardware, fit both centers,
     and learn the additive offset between them.
 
-    The returned ``offset`` is in the native motor units. For the Phase 1 theta
-    motors, ``offset_deg`` is the value typically written to the offset PV.
+    Parameters
+    ----------
+    RE : bluesky.RunEngine
+        RunEngine used for both the model and hardware scans.
+    sim_backend, hw_backend : object
+        Backend namespaces with matching motor and diagnostic attribute names.
+        In the hardware workflow, these can be the LUME/model-PV backend and
+        raw-diode hardware backend from ``scripts/SnD_Phase1.py``.
+    motor_attr : str
+        Name of the motor attribute to scan.
+    detector_attr : str
+        Name of the diagnostic signal to fit.
+    norm_detector_attr : str
+        Name of the reference signal used to fit ``detector / norm_detector``.
+    offset_pv : str
+        EPICS PV that receives the learned offset when ``write=True``.
+    start, stop : float
+        Relative scan limits in the backend motor units.
+    steps : int
+        Number of scan points.
+    shots_per_step : int, optional
+        Number of samples to average at each scan point.
+    duration : float, optional
+        AvgSignal averaging duration passed to the scan helper.
+    move : bool, optional
+        If True, move each backend motor to its fitted center after scanning.
+    write : bool, optional
+        If True, write the learned offset to ``offset_pv``.
+
+    Returns
+    -------
+    dict
+        Result dictionary containing fitted centers, the learned ``offset``,
+        scan results, and write/move metadata. ``offset`` is in the backend
+        motor units.
     """
     sim_motor = getattr(sim_backend, motor_attr)
     sim_detector = getattr(sim_backend, detector_attr)
+    sim_norm_detector = getattr(sim_backend, norm_detector_attr)
     hw_motor = getattr(hw_backend, motor_attr)
     hw_detector = getattr(hw_backend, detector_attr)
+    hw_norm_detector = getattr(hw_backend, norm_detector_attr)
 
     sim_result = scan_fit_center(
-        RE_sim,
+        RE,
         sim_motor,
         sim_detector,
+        sim_norm_detector,
         start=start,
         stop=stop,
         steps=steps,
         shots_per_step=shots_per_step,
+        averaging_duration=duration,
         move=False,
     )
     hw_result = scan_fit_center(
-        RE_hw,
+        RE,
         hw_motor,
         hw_detector,
+        hw_norm_detector,
         start=start,
         stop=stop,
         steps=steps,
         shots_per_step=shots_per_step,
+        averaging_duration=duration,
         move=False,
     )
 
@@ -62,39 +100,24 @@ def learn_phase1_offset(
     hw_center = float(hw_result["center"])
 
     if move:
-        RE_sim(bps.mv(sim_motor, sim_center))
-        RE_hw(bps.mv(hw_motor, hw_center))
+        RE(bps.mv(sim_motor, sim_center))
+        RE(bps.mv(hw_motor, hw_center))
 
     offset = hw_center - sim_center
-    offset_deg = math.degrees(offset)
 
     if write:
-        if caput_fn is None:
-            caput_fn = importlib.import_module("epics").caput
-        caput_fn(offset_pv, offset_deg)
+        importlib.import_module("epics").caput(offset_pv, offset)
 
     return {
         "motor": motor_attr,
         "detector": detector_attr,
+        "norm_detector": norm_detector_attr,
         "offset_pv": offset_pv,
         "sim_center": sim_center,
         "hw_center": hw_center,
         "offset": offset,
-        "offset_deg": offset_deg,
         "sim_result": sim_result,
         "hw_result": hw_result,
         "moved": move,
         "wrote_pv": write,
     }
-
-
-def write_phase1_offset(result, caput_fn=None):
-    """
-    Write a learned Phase 1 offset to the corresponding EPICS PV in degrees.
-    """
-    if caput_fn is None:
-        caput_fn = importlib.import_module("epics").caput
-
-    caput_fn(result["offset_pv"], result["offset_deg"])
-    return result["offset_pv"], result["offset_deg"]
-


### PR DESCRIPTION
## Summary
- Update Phase 1 offset learning to use the same hardware-backend pattern as `scripts/SnD_Phase1.py`.
- Add normalized detector (`detector / norm_detector`) to match the updated `scan_fit_center()`.

## Usage

```python
result = learn_phase1_offset(
    RE=RE,
    sim_backend=MODEL_BACKEND,
    hw_backend=HARDWARE_BACKEND,
    motor_attr="t2_th",
    detector_attr="dcc_sum",
    norm_detector_attr="di_sum",
    offset_pv="XCS:USER:SND:T2_TH_OFFSET",
    start=-50e-6 * 180 / np.pi,
    stop=50e-6 * 180 / np.pi,
    steps=10,
    shots_per_step=10,
    duration=1,
    move=True,
    write=False,
)
```
Setting `move=True means after fitting, it moves the motor to the fitted center. Set `write=True` to write the offset PV.